### PR TITLE
Fix/search

### DIFF
--- a/astro-frontend/src/components/EventSearch.tsx
+++ b/astro-frontend/src/components/EventSearch.tsx
@@ -7,6 +7,7 @@ import { Locale } from "~/enums/locale";
 import { searchEvents } from "~/services/events/event-search";
 import { getPlaceholderImage } from "~/helpers/get-placeholder-image";
 import { getNoResultsMessage } from "~/helpers/get-no-result-message";
+import { getEventListPageUrl } from "~/helpers/get-event-list-page-url";
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -53,6 +54,7 @@ export default function EventSearch({
   const [loading, setLoading] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState(-1);
   const [open, setOpen] = React.useState(false);
+  const [navigating, setNavigating] = React.useState(false);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -126,8 +128,10 @@ export default function EventSearch({
     if (e.key === "Enter") {
       e.preventDefault();
       const index = activeIndex >= 0 ? activeIndex : 0;
-      const base = locale === Locale.KOK ? "/kok" : "";
-      window.location.href = `${base}/events/${results[index].slug}`;
+      setNavigating(true);
+      getEventListPageUrl(results[index].id, locale).then((url) => {
+        window.location.href = url;
+      });
     }
 
     if (e.key === "Escape") {
@@ -219,7 +223,9 @@ export default function EventSearch({
             {!loading && results.length > 0 && (
               <ul
                 role="listbox"
-                className="max-h-64 overflow-y-auto"
+                className={`max-h-64 overflow-y-auto ${
+                  navigating ? "pointer-events-none opacity-60" : ""
+                }`}
                 onMouseLeave={() => setActiveIndex(-1)}
               >
                 {results.map((event, index) => {
@@ -256,8 +262,10 @@ export default function EventSearch({
                       }`}
                       onMouseEnter={() => setActiveIndex(index)}
                       onClick={() => {
-                        const base = locale === Locale.KOK ? "/kok" : "";
-                        window.location.href = `${base}/events/${event.slug}`;
+                        setNavigating(true);
+                        getEventListPageUrl(event.id, locale).then((url) => {
+                          window.location.href = url;
+                        });
                       }}
                     >
                       <div className="min-w-0 flex-1">

--- a/astro-frontend/src/components/EventSearch.tsx
+++ b/astro-frontend/src/components/EventSearch.tsx
@@ -129,7 +129,7 @@ export default function EventSearch({
       e.preventDefault();
       const index = activeIndex >= 0 ? activeIndex : 0;
       setNavigating(true);
-      getEventListPageUrl(results[index].id, locale).then((url) => {
+      getEventListPageUrl(results[index].id, locale, associationSlug).then((url) => {
         window.location.href = url;
       });
     }
@@ -263,7 +263,7 @@ export default function EventSearch({
                       onMouseEnter={() => setActiveIndex(index)}
                       onClick={() => {
                         setNavigating(true);
-                        getEventListPageUrl(event.id, locale).then((url) => {
+                        getEventListPageUrl(event.id, locale, associationSlug).then((url) => {
                           window.location.href = url;
                         });
                       }}

--- a/astro-frontend/src/components/event-card.astro
+++ b/astro-frontend/src/components/event-card.astro
@@ -47,7 +47,7 @@ const displayDescription =
     : (shortDescriptionKok ?? shortDescriptionEn ?? "No description available");
 ---
 
-<div id={slug} class={cn("flex flex-col border border-gray-200", className)} {...rest}>
+<div id={slug} class={cn("flex flex-col border border-gray-200 scroll-mt-24", className)} {...rest}>
   <div class="event-image w-full">
     <NetworkImage
       src={imageUrl}

--- a/astro-frontend/src/components/event-card.astro
+++ b/astro-frontend/src/components/event-card.astro
@@ -47,7 +47,7 @@ const displayDescription =
     : (shortDescriptionKok ?? shortDescriptionEn ?? "No description available");
 ---
 
-<div class={cn("flex flex-col border border-gray-200", className)} {...rest}>
+<div id={slug} class={cn("flex flex-col border border-gray-200", className)} {...rest}>
   <div class="event-image w-full">
     <NetworkImage
       src={imageUrl}

--- a/astro-frontend/src/constants/index.ts
+++ b/astro-frontend/src/constants/index.ts
@@ -9,6 +9,9 @@ export const SITE_URL = "https://pompeichurch.in";
 
 export const ITEMS_PER_PAGE = 6; // number of items to show per page
 
+/** Default sort order for events — shared by listEvents and find-page.ts. */
+export const EVENT_DEFAULT_SORT = ["eventDate:desc", "createdAt:desc"];
+
 export const PAGINATION_BETWEEN_COUNT = 1; // how many pages to show on each side of currentPage
 
 export const EXPIRE_TIME = 24 * 60 * 60 * 1000 * 3; // milliseconds in three days

--- a/astro-frontend/src/helpers/get-event-list-page-url.ts
+++ b/astro-frontend/src/helpers/get-event-list-page-url.ts
@@ -4,20 +4,30 @@ import { Locale } from "~/enums/locale";
  * Calls the `/api/events/find-page` endpoint to determine which paginated
  * events list page contains the given event, then returns the navigable URL.
  *
- * @param {number} eventId - The numeric `id` of the event.
- * @param {Locale} locale  - The current locale, used to add the `/kok` prefix when needed.
- * @returns {Promise<string>} A URL string like `/events?p=2` or `/kok/events?p=2`.
- *          Falls back to `/events` (or `/kok/events`) if the lookup fails.
+ * @param {number} eventId        - The numeric `id` of the event.
+ * @param {Locale} locale         - The current locale, used to add the `/kok` prefix when needed.
+ * @param {string} [associationSlug] - When provided, scopes the lookup to that association's
+ *                                    event list and returns `/associations/[slug]/events?p=N`.
+ * @returns {Promise<string>} A URL like `/events?p=2`, `/associations/slug/events?p=1`,
+ *          or `/kok/events?p=2`. Falls back to the list root if the lookup fails.
  */
 async function getEventListPageUrl(
   eventId: number,
   locale: Locale,
+  associationSlug?: string,
 ): Promise<string> {
   const base = locale === Locale.KOK ? "/kok" : "";
-  const fallback = `${base}/events`;
+
+  const fallback = associationSlug
+    ? `${base}/associations/${associationSlug}/events`
+    : `${base}/events`;
 
   try {
-    const res = await fetch(`/api/events/find-page?id=${eventId}`);
+    const apiUrl = associationSlug
+      ? `/api/events/find-page?id=${eventId}&association=${associationSlug}`
+      : `/api/events/find-page?id=${eventId}`;
+
+    const res = await fetch(apiUrl);
 
     if (!res.ok) return fallback;
 
@@ -26,7 +36,8 @@ async function getEventListPageUrl(
     if (!json.page || json.page < 1) return fallback;
 
     const hash = json.slug ? `#${json.slug}` : "";
-    return `${base}/events?p=${json.page}${hash}`;
+
+    return `${fallback}?p=${json.page}${hash}`;
   } catch {
     return fallback;
   }

--- a/astro-frontend/src/helpers/get-event-list-page-url.ts
+++ b/astro-frontend/src/helpers/get-event-list-page-url.ts
@@ -21,11 +21,12 @@ async function getEventListPageUrl(
 
     if (!res.ok) return fallback;
 
-    const json = (await res.json()) as { page?: number };
+    const json = (await res.json()) as { page?: number; slug?: string };
 
     if (!json.page || json.page < 1) return fallback;
 
-    return `${base}/events?p=${json.page}`;
+    const hash = json.slug ? `#${json.slug}` : "";
+    return `${base}/events?p=${json.page}${hash}`;
   } catch {
     return fallback;
   }

--- a/astro-frontend/src/helpers/get-event-list-page-url.ts
+++ b/astro-frontend/src/helpers/get-event-list-page-url.ts
@@ -1,0 +1,34 @@
+import { Locale } from "~/enums/locale";
+
+/**
+ * Calls the `/api/events/find-page` endpoint to determine which paginated
+ * events list page contains the given event, then returns the navigable URL.
+ *
+ * @param {number} eventId - The numeric `id` of the event.
+ * @param {Locale} locale  - The current locale, used to add the `/kok` prefix when needed.
+ * @returns {Promise<string>} A URL string like `/events?p=2` or `/kok/events?p=2`.
+ *          Falls back to `/events` (or `/kok/events`) if the lookup fails.
+ */
+async function getEventListPageUrl(
+  eventId: number,
+  locale: Locale,
+): Promise<string> {
+  const base = locale === Locale.KOK ? "/kok" : "";
+  const fallback = `${base}/events`;
+
+  try {
+    const res = await fetch(`/api/events/find-page?id=${eventId}`);
+
+    if (!res.ok) return fallback;
+
+    const json = (await res.json()) as { page?: number };
+
+    if (!json.page || json.page < 1) return fallback;
+
+    return `${base}/events?p=${json.page}`;
+  } catch {
+    return fallback;
+  }
+}
+
+export { getEventListPageUrl };

--- a/astro-frontend/src/pages/api/events/find-page.ts
+++ b/astro-frontend/src/pages/api/events/find-page.ts
@@ -1,19 +1,17 @@
 import type { APIRoute } from "astro";
 import { strapiFetch } from "~/helpers/strapi-fetch";
 import { ROUTES } from "~/constants/strapi-endpoints";
-import { ITEMS_PER_PAGE } from "~/constants/index.ts";
+import { ITEMS_PER_PAGE, EVENT_DEFAULT_SORT } from "~/constants/index.ts";
 import type { EventData } from "~/models/event";
 
-const SORT_PARAMS = {
-  "sort[0]": "eventDate:desc",
-  "sort[1]": "createdAt:desc",
-};
-
 /**
- * GET /api/events/find-page?id=<eventId>
+ * GET /api/events/find-page?id=<eventId>[&association=<slug>]
  *
  * Fetches all event IDs from Strapi in the same sort order as the events list
  * page, then computes which page the given event falls on based on ITEMS_PER_PAGE.
+ *
+ * When `association` is provided the lookup is scoped to that association's
+ * events, so the returned page number is correct for /associations/[slug]/events.
  *
  * Step 1: Fetch one record with `pagination[withCount]=true` to get the real total.
  * Step 2: Fetch all IDs using that total as pageSize (fields[0]=id only, no populate).
@@ -22,6 +20,7 @@ const SORT_PARAMS = {
  */
 export const GET: APIRoute = async ({ url }) => {
   const rawId = url.searchParams.get("id");
+  const associationSlug = url.searchParams.get("association") ?? undefined;
 
   if (!rawId) {
     return new Response(JSON.stringify({ error: "Missing required param: id" }), {
@@ -39,15 +38,24 @@ export const GET: APIRoute = async ({ url }) => {
     });
   }
 
+  // Build shared query params (sort + optional association filter)
+  function buildQueryParams(extra: Record<string, string>) {
+    const params = new URLSearchParams(extra);
+    EVENT_DEFAULT_SORT.forEach((s, i) => params.append(`sort[${i}]`, s));
+    if (associationSlug) {
+      params.append("filters[association][slug][$eq]", associationSlug);
+    }
+    return params;
+  }
+
   // Step 1: get the real total count without fetching all records
   const countData = await strapiFetch<EventData>({
     endpoint: ROUTES.EVENTS,
-    queryParams: new URLSearchParams({
+    queryParams: buildQueryParams({
       "fields[0]": "id",
       "pagination[page]": "1",
       "pagination[pageSize]": "1",
       "pagination[withCount]": "true",
-      ...SORT_PARAMS,
     }),
   });
 
@@ -63,12 +71,11 @@ export const GET: APIRoute = async ({ url }) => {
   // Step 2: fetch all IDs in sort order using the real total as the page size
   const data = await strapiFetch<EventData>({
     endpoint: ROUTES.EVENTS,
-    queryParams: new URLSearchParams({
+    queryParams: buildQueryParams({
       "fields[0]": "id",
       "fields[1]": "slug",
       "pagination[page]": "1",
       "pagination[pageSize]": String(total),
-      ...SORT_PARAMS,
     }),
   });
 

--- a/astro-frontend/src/pages/api/events/find-page.ts
+++ b/astro-frontend/src/pages/api/events/find-page.ts
@@ -18,7 +18,7 @@ const SORT_PARAMS = {
  * Step 1: Fetch one record with `pagination[withCount]=true` to get the real total.
  * Step 2: Fetch all IDs using that total as pageSize (fields[0]=id only, no populate).
  *
- * @returns JSON `{ page: number }` — the 1-based page number the event appears on.
+ * @returns JSON `{ page: number, slug: string }` — the 1-based page number and event slug.
  */
 export const GET: APIRoute = async ({ url }) => {
   const rawId = url.searchParams.get("id");
@@ -65,6 +65,7 @@ export const GET: APIRoute = async ({ url }) => {
     endpoint: ROUTES.EVENTS,
     queryParams: new URLSearchParams({
       "fields[0]": "id",
+      "fields[1]": "slug",
       "pagination[page]": "1",
       "pagination[pageSize]": String(total),
       ...SORT_PARAMS,
@@ -83,8 +84,9 @@ export const GET: APIRoute = async ({ url }) => {
   }
 
   const page = Math.floor(index / ITEMS_PER_PAGE) + 1;
+  const slug = data?.data?.[index]?.slug ?? "";
 
-  return new Response(JSON.stringify({ page }), {
+  return new Response(JSON.stringify({ page, slug }), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });

--- a/astro-frontend/src/pages/api/events/find-page.ts
+++ b/astro-frontend/src/pages/api/events/find-page.ts
@@ -1,0 +1,67 @@
+import type { APIRoute } from "astro";
+import { strapiFetch } from "~/helpers/strapi-fetch";
+import { ROUTES } from "~/constants/strapi-endpoints";
+import { ITEMS_PER_PAGE } from "~/constants/index.ts";
+import type { EventData } from "~/models/event";
+
+/**
+ * GET /api/events/find-page?id=<eventId>
+ *
+ * Fetches all event IDs from Strapi in the same sort order as the events list
+ * page, then computes which page the given event falls on based on ITEMS_PER_PAGE.
+ *
+ * Uses a single Strapi request fetching only the `id` field (no populate) for
+ * maximum efficiency.
+ *
+ * @returns JSON `{ page: number }` — the 1-based page number the event appears on.
+ */
+export const GET: APIRoute = async ({ url }) => {
+  const rawId = url.searchParams.get("id");
+
+  if (!rawId) {
+    return new Response(JSON.stringify({ error: "Missing required param: id" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const eventId = Number(rawId);
+
+  if (!Number.isInteger(eventId) || eventId <= 0) {
+    return new Response(JSON.stringify({ error: "Invalid id: must be a positive integer" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const queryParams = new URLSearchParams({
+    "fields[0]": "id",
+    "pagination[page]": "1",
+    "pagination[pageSize]": "1000",
+    "sort[0]": "eventDate:desc",
+    "sort[1]": "createdAt:desc",
+  });
+
+  const data = await strapiFetch<EventData>({
+    endpoint: ROUTES.EVENTS,
+    queryParams,
+  });
+
+  const ids = data?.data?.map((e) => e.id) ?? [];
+
+  const index = ids.indexOf(eventId);
+
+  if (index === -1) {
+    return new Response(JSON.stringify({ error: "Event not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const page = Math.floor(index / ITEMS_PER_PAGE) + 1;
+
+  return new Response(JSON.stringify({ page }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/astro-frontend/src/pages/api/events/find-page.ts
+++ b/astro-frontend/src/pages/api/events/find-page.ts
@@ -4,14 +4,19 @@ import { ROUTES } from "~/constants/strapi-endpoints";
 import { ITEMS_PER_PAGE } from "~/constants/index.ts";
 import type { EventData } from "~/models/event";
 
+const SORT_PARAMS = {
+  "sort[0]": "eventDate:desc",
+  "sort[1]": "createdAt:desc",
+};
+
 /**
  * GET /api/events/find-page?id=<eventId>
  *
  * Fetches all event IDs from Strapi in the same sort order as the events list
  * page, then computes which page the given event falls on based on ITEMS_PER_PAGE.
  *
- * Uses a single Strapi request fetching only the `id` field (no populate) for
- * maximum efficiency.
+ * Step 1: Fetch one record with `pagination[withCount]=true` to get the real total.
+ * Step 2: Fetch all IDs using that total as pageSize (fields[0]=id only, no populate).
  *
  * @returns JSON `{ page: number }` — the 1-based page number the event appears on.
  */
@@ -34,17 +39,36 @@ export const GET: APIRoute = async ({ url }) => {
     });
   }
 
-  const queryParams = new URLSearchParams({
-    "fields[0]": "id",
-    "pagination[page]": "1",
-    "pagination[pageSize]": "1000",
-    "sort[0]": "eventDate:desc",
-    "sort[1]": "createdAt:desc",
+  // Step 1: get the real total count without fetching all records
+  const countData = await strapiFetch<EventData>({
+    endpoint: ROUTES.EVENTS,
+    queryParams: new URLSearchParams({
+      "fields[0]": "id",
+      "pagination[page]": "1",
+      "pagination[pageSize]": "1",
+      "pagination[withCount]": "true",
+      ...SORT_PARAMS,
+    }),
   });
 
+  const total = countData?.meta?.pagination?.total ?? 0;
+
+  if (total === 0) {
+    return new Response(JSON.stringify({ error: "Event not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Step 2: fetch all IDs in sort order using the real total as the page size
   const data = await strapiFetch<EventData>({
     endpoint: ROUTES.EVENTS,
-    queryParams,
+    queryParams: new URLSearchParams({
+      "fields[0]": "id",
+      "pagination[page]": "1",
+      "pagination[pageSize]": String(total),
+      ...SORT_PARAMS,
+    }),
   });
 
   const ids = data?.data?.map((e) => e.id) ?? [];

--- a/astro-frontend/src/services/events/list-events.ts
+++ b/astro-frontend/src/services/events/list-events.ts
@@ -1,6 +1,7 @@
 import { ROUTES } from "~/constants/strapi-endpoints";
 import { strapiFetch } from "~/helpers/strapi-fetch";
 import type { EventData, EventsPagination } from "~/models/event";
+import { EVENT_DEFAULT_SORT } from "~/constants/index.ts";
 
 /**
  * Fetches a paginated list of events from the Strapi CMS.
@@ -21,7 +22,7 @@ async function listEvents(args?: {
   const {
     page = 1,
     pageSize = 25,
-    sortBy = ["eventDate:desc", "createdAt:desc"],
+    sortBy = EVENT_DEFAULT_SORT,
     filters,
   } = args ?? {};
 


### PR DESCRIPTION
Previously, clicking a search result in the events search bar navigated to the individual event page (/events/<slug>). This PR changes that behaviour so users land on the paginated events list page that contains the event, scrolled directly to that event's card.